### PR TITLE
Should be exactly 256 bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ go get github.com/jbenet/ipfs-senc/ipfs-senc
 ### How to encrypt & share
 
 ```
-# encrypt with a known key. (>256bits please)
+# encrypt with a known key. (256bits please)
 ipfs-senc share --key <secret-key> <path-to-file-or-directory>
 
 # encrypt with a randomly generated key. will be printed out.


### PR DESCRIPTION
senc feeds it into crypto/aes.NewCipher https://golang.org/pkg/crypto/aes/#NewCipher, which only supports AES 128, 192, or 256